### PR TITLE
Added additional templates and fixed a minor bug.

### DIFF
--- a/proxmox-cloudinit-script/pve_cloudinit.sh
+++ b/proxmox-cloudinit-script/pve_cloudinit.sh
@@ -2,7 +2,7 @@
 
 choose_distro() {
     echo -e "Welcome to the Proxmox Cloud-Init template installer!\n"
-    PS3="Please choose a distro image to download (1-6): "
+    PS3="Please choose a distro image to download (1-9): "
     local distro_list=("Ubuntu Cloud 22.04 LTS" "Ubuntu Cloud 22.04 LTS (Minimal)" "Ubuntu Cloud 24.04 LTS" "Ubuntu Cloud 24.04 LTS (Minimal)" "Debian 11 (GenericCloud)" "Debian 12 (GenericCloud)"
         "Fedora Cloud 40 (base)" "AlmaLinux 9 (GenericCloud)" "Quit")
     select distro in "${distro_list[@]}"; do
@@ -24,7 +24,7 @@ choose_distro() {
             break
             ;;
         "${distro_list[2]}")
-            echo -e "${distro_list[0]}"
+            echo -e "${distro_list[2]}"
             IMAGE_URL="https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img"
             CHECKSUM_URL="https://cloud-images.ubuntu.com/releases/noble/release/SHA256SUMS"
             SHA=256
@@ -32,7 +32,7 @@ choose_distro() {
             break
             ;;
         "${distro_list[3]}")
-            echo -e "${distro_list[1]}"
+            echo -e "${distro_list[3]}"
             IMAGE_URL="https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
             CHECKSUM_URL="https://cloud-images.ubuntu.com/minimal/releases/noble/release/SHA256SUMS"
             SHA=256
@@ -40,7 +40,7 @@ choose_distro() {
             break
             ;;
         "${distro_list[4]}")
-            echo -e "${distro_list[2]}"
+            echo -e "${distro_list[4]}"
             IMAGE_URL="https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2"
             CHECKSUM_URL="https://cloud.debian.org/images/cloud/bullseye/latest/SHA512SUMS"
             SHA=512
@@ -48,7 +48,7 @@ choose_distro() {
             break
             ;;
         "${distro_list[5]}")
-            echo -e "${distro_list[2]}"
+            echo -e "${distro_list[5]}"
             IMAGE_URL="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
             CHECKSUM_URL="https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS"
             SHA=512
@@ -56,7 +56,7 @@ choose_distro() {
             break
             ;;
         "${distro_list[6]}")
-            echo -e "${distro_list[3]}"
+            echo -e "${distro_list[6]}"
             IMAGE_URL="https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2"
             CHECKSUM_URL="https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-40-1.14-x86_64-CHECKSUM"
             SHA=256

--- a/proxmox-cloudinit-script/pve_cloudinit.sh
+++ b/proxmox-cloudinit-script/pve_cloudinit.sh
@@ -250,7 +250,7 @@ download_image() {
 
 qm_create() {
     # create a new VM with VirtIO SCSI single controller
-    qm create "${ID}" --name "${TEMPLATE_NAME}" --memory 2048 --core 1 \
+    qm create "${ID}" --name "${TEMPLATE_NAME}" --memory 2048 --balloon 1024 --core 1 --cpu x86-64-v2-AES --numa 1 \
         --net0 virtio,bridge=vmbr0,firewall=1 --scsihw virtio-scsi-single \
         --agent "${agent_params}"
 

--- a/proxmox-cloudinit-script/pve_cloudinit.sh
+++ b/proxmox-cloudinit-script/pve_cloudinit.sh
@@ -2,9 +2,9 @@
 
 choose_distro() {
     echo -e "Welcome to the Proxmox Cloud-Init template installer!\n"
-    PS3="Please choose a distro image to download (1-9): "
+    PS3="Please choose a distro image to download (1-12): "
     local distro_list=("Ubuntu Cloud 22.04 LTS" "Ubuntu Cloud 22.04 LTS (Minimal)" "Ubuntu Cloud 24.04 LTS" "Ubuntu Cloud 24.04 LTS (Minimal)" "Debian 11 (GenericCloud)" "Debian 12 (GenericCloud)"
-        "Fedora Cloud 40 (base)" "AlmaLinux 9 (GenericCloud)" "Quit")
+        "Fedora Cloud 40 (base)" "Fedora Cloud 41 (base)" "AlmaLinux 9 (GenericCloud)" "RockyLinux 9 (GenericCloud)"  "FreeBSD 14.1 (Basic)" "CentOS 9 Stream (GenericCloud)" "Quit")
     select distro in "${distro_list[@]}"; do
         case $distro in
         "${distro_list[0]}")
@@ -64,11 +64,43 @@ choose_distro() {
             break
             ;;
         "${distro_list[7]}")
-            echo -e "${distro_list[4]}"
+            echo -e "${distro_list[7]}"
+            IMAGE_URL="https://mirror.nl.mirhosting.net/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
+            CHECKSUM_URL="https://mirror.i3d.net/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-41-1.4-x86_64-CHECKSUM"
+            SHA=256
+            CLOUDIMG_NAME="Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
+            break
+            ;;
+        "${distro_list[8]}")
+            echo -e "${distro_list[8]}"
             IMAGE_URL="https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
             CHECKSUM_URL="https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/CHECKSUM"
             SHA=256
             CLOUDIMG_NAME="AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
+            break
+            ;;
+        "${distro_list[9]}")
+            echo -e "${distro_list[9]}"
+            IMAGE_URL="https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2"
+            CHECKSUM_URL="https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2.CHECKSUM"
+            SHA=256
+            CLOUDIMG_NAME="Rocky-9-GenericCloud.latest.x86_64.qcow2"
+            break
+            ;;
+        "${distro_list[10]}")
+            echo -e "${distro_list[10]}"
+            IMAGE_URL="https://download.freebsd.org/releases/VM-IMAGES/14.1-RELEASE/amd64/Latest/FreeBSD-14.1-RELEASE-amd64-BASIC-CLOUDINIT-zfs.qcow2.xz"
+            CHECKSUM_URL="https://download.freebsd.org/releases/VM-IMAGES/14.1-RELEASE/amd64/Latest/CHECKSUM.SHA256"
+            SHA=256
+            CLOUDIMG_NAME="FreeBSD-14.1-RELEASE-amd64-BASIC-CLOUDINIT-zfs.qcow2.xz"
+            break
+            ;;
+        "${distro_list[11]}")
+            echo -e "${distro_list[11]}"
+            IMAGE_URL="https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2"
+            CHECKSUM_URL="https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2.SHA256SUM"
+            SHA=256
+            CLOUDIMG_NAME="CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2"
             break
             ;;
         "Quit")

--- a/proxmox-cloudinit-script/pve_cloudinit.sh
+++ b/proxmox-cloudinit-script/pve_cloudinit.sh
@@ -13,6 +13,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud-images.ubuntu.com/releases/jammy/release/SHA256SUMS"
             SHA=256
             CLOUDIMG_NAME="ubuntu-22.04-server-cloudimg-amd64.img"
+            TEMPLATE_NAME="ubuntu-22.04-template"
             break
             ;;
         "${distro_list[1]}")
@@ -21,6 +22,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud-images.ubuntu.com/minimal/releases/jammy/release/SHA256SUMS"
             SHA=256
             CLOUDIMG_NAME="ubuntu-22.04-minimal-cloudimg-amd64.img"
+            TEMPLATE_NAME="ubuntu-22.04-minimal-template"
             break
             ;;
         "${distro_list[2]}")
@@ -29,6 +31,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud-images.ubuntu.com/releases/noble/release/SHA256SUMS"
             SHA=256
             CLOUDIMG_NAME="ubuntu-24.04-server-cloudimg-amd64.img"
+            TEMPLATE_NAME="ubuntu-24.04-template"
             break
             ;;
         "${distro_list[3]}")
@@ -37,6 +40,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud-images.ubuntu.com/minimal/releases/noble/release/SHA256SUMS"
             SHA=256
             CLOUDIMG_NAME="ubuntu-24.04-minimal-cloudimg-amd64.img"
+            TEMPLATE_NAME="ubuntu-24.04-minimal-template"
             break
             ;;
         "${distro_list[4]}")
@@ -45,6 +49,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud.debian.org/images/cloud/bullseye/latest/SHA512SUMS"
             SHA=512
             CLOUDIMG_NAME="debian-11-genericcloud-amd64.qcow2"
+            TEMPLATE_NAME="debian-11-template"
             break
             ;;
         "${distro_list[5]}")
@@ -53,6 +58,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud.debian.org/images/cloud/bookworm/latest/SHA512SUMS"
             SHA=512
             CLOUDIMG_NAME="debian-12-genericcloud-amd64.qcow2"
+            TEMPLATE_NAME="debian-12-template"
             break
             ;;
         "${distro_list[6]}")
@@ -61,6 +67,7 @@ choose_distro() {
             CHECKSUM_URL="https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-40-1.14-x86_64-CHECKSUM"
             SHA=256
             CLOUDIMG_NAME="Fedora-Cloud-40-1.14-x86_64.qcow2"
+            TEMPLATE_NAME="fedora-40-template"
             break
             ;;
         "${distro_list[7]}")
@@ -69,6 +76,7 @@ choose_distro() {
             CHECKSUM_URL="https://mirror.i3d.net/pub/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-41-1.4-x86_64-CHECKSUM"
             SHA=256
             CLOUDIMG_NAME="Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
+            TEMPLATE_NAME="fedora-41-template"
             break
             ;;
         "${distro_list[8]}")
@@ -77,6 +85,7 @@ choose_distro() {
             CHECKSUM_URL="https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/CHECKSUM"
             SHA=256
             CLOUDIMG_NAME="AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
+            TEMPLATE_NAME="almalinux-9-template"
             break
             ;;
         "${distro_list[9]}")
@@ -85,6 +94,7 @@ choose_distro() {
             CHECKSUM_URL="https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2.CHECKSUM"
             SHA=256
             CLOUDIMG_NAME="Rocky-9-GenericCloud.latest.x86_64.qcow2"
+            TEMPLATE_NAME="rockylinux-9-template"
             break
             ;;
         "${distro_list[10]}")
@@ -93,6 +103,7 @@ choose_distro() {
             CHECKSUM_URL="https://download.freebsd.org/releases/VM-IMAGES/14.1-RELEASE/amd64/Latest/CHECKSUM.SHA256"
             SHA=256
             CLOUDIMG_NAME="FreeBSD-14.1-RELEASE-amd64-BASIC-CLOUDINIT-zfs.qcow2.xz"
+            TEMPLATE_NAME="freebsd-14.1-template"
             break
             ;;
         "${distro_list[11]}")
@@ -101,6 +112,7 @@ choose_distro() {
             CHECKSUM_URL="https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2.SHA256SUM"
             SHA=256
             CLOUDIMG_NAME="CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2"
+            TEMPLATE_NAME="Centos-9-stream-template"
             break
             ;;
         "Quit")
@@ -367,7 +379,6 @@ main() {
     choose_storage "$@"
     choose_agent "$@"
     choose_libguestfs "$@"
-    TEMPLATE_NAME="Template-Cloud-init"
 
     # # add date to filename
     # date=$(date --iso-8601=date)


### PR DESCRIPTION
Hi,

I created this issue ([Unable to install image over id of 6](https://github.com/roib20/proxmox-scripts/issues/20)) and decided to solve it immeditaly.
- Added some additional templates
- Fixed a bug where the chosen template name was not displayed correctly
- Started using the `TEMPLATE_NAME` variable from the chosen distro
- Enabled Ballooning to `1024/2048`
- Ensured a genericly great and used cpu type is used `x86-64-v2-AES`
- Enabled on the CPU